### PR TITLE
fix sinter `decode_via_files` bitpack format and default to not showing progress bar

### DIFF
--- a/src/relay_bp/stim/sinter/decoders.py
+++ b/src/relay_bp/stim/sinter/decoders.py
@@ -28,10 +28,14 @@ class SinterCompiledDecoder_BP(CompiledDecoder):
         observable_decoder: relay_bp.ObservableDecoderRunner,
         check_matrices: CheckMatrices,
         parallel: bool = False,
+        show_progress: bool = False,
+        leave_progress_bar_on_finish: bool = False,
     ):
         self.observable_decoder = observable_decoder
         self.parallel = parallel
         self.check_matrices = check_matrices
+        self.show_progress = show_progress
+        self.leave_progress_bar_on_finish = leave_progress_bar_on_finish
 
     def decode_shots_bit_packed(
         self,
@@ -47,7 +51,10 @@ class SinterCompiledDecoder_BP(CompiledDecoder):
             syndromes = (syndromes + self.check_matrices.syndrome_bias) % 2
 
         predictions = self.observable_decoder.decode_observables_batch(
-            syndromes, parallel=self.parallel
+            syndromes,
+            parallel=self.parallel,
+            progress_bar=self.show_progress,
+            leave_progress_bar_on_finish=self.leave_progress_bar_on_finish,
         )
 
         if self.check_matrices.observables_bias is not None:
@@ -64,12 +71,16 @@ class SinterDecoder_BaseBP(Decoder):
         decomposed_hyperedges: bool | None = None,
         prune_decided_errors: bool = True,
         threshold: float = 0.0,
+        show_progress: bool = False,
+        leave_progress_bar_on_finish: bool = False,
     ):
         f"""Class for decoding stim circuits with sinter and relay-bp."""
         self.parallel = parallel
         self.decomposed_hyperedges = decomposed_hyperedges
         self.prune_decided_errors = prune_decided_errors
         self.threshold = threshold
+        self.show_progress = show_progress
+        self.leave_progress_bar_on_finish = leave_progress_bar_on_finish
 
     def build_observable_decoder(
         self, dem: stim.DetectorErrorModel
@@ -90,6 +101,8 @@ class SinterDecoder_BaseBP(Decoder):
             observable_decoder_runner,
             check_matrices=check_matrices,
             parallel=self.parallel,
+            show_progress=self.show_progress,
+            leave_progress_bar_on_finish=self.leave_progress_bar_on_finish,
         )
 
     def decode_via_files(
@@ -127,6 +140,8 @@ class SinterDecoder_BaseBP(Decoder):
         predictions = observable_decoder.decode_observables_batch(
             syndromes,
             parallel=self.parallel,
+            progress_bar=self.show_progress,
+            leave_progress_bar_on_finish=self.leave_progress_bar_on_finish,
         )
 
         if check_matrices.observables_bias is not None:

--- a/src/relay_bp/stim/sinter/decoders.py
+++ b/src/relay_bp/stim/sinter/decoders.py
@@ -148,7 +148,7 @@ class SinterDecoder_BaseBP(Decoder):
             predictions = (predictions + check_matrices.observables_bias) % 2
 
         stim.write_shot_data_file(
-            data=predictions,
+            data=np.packbits(predictions, axis=1, bitorder="little"),
             path=obs_predictions_b8_out_path,
             format="b8",
             num_observables=dem.num_observables,


### PR DESCRIPTION
This should fix #9 and #12 

As a side note, I think enabling the progress bar by default in the Python interface could be useful when people are not using sinter for large-scale simulation. Thus, I only modified the sinter python glue instead of the default value like that in #10 