### PR TITLE
Fix Memory parameter rest

### DIFF
--- a/crates/relay_bp/src/bp/relay.rs
+++ b/crates/relay_bp/src/bp/relay.rs
@@ -206,11 +206,7 @@ where
     }
 
     /// Decode with the inner decoder
-    fn decode_inner(
-        &mut self,
-        detectors: ArrayView1<Bit>,
-        max_iter: usize,
-    ) -> DecodeResult {
+    fn decode_inner(&mut self, detectors: ArrayView1<Bit>, max_iter: usize) -> DecodeResult {
         let mut success: bool = false;
         let mut decoded_detectors = Array1::default(detectors.dim());
 


### PR DESCRIPTION
Resetting memory parameters between faults was not properly done.
This seems to have only a small impact on the rotated surface code and LDPC codes, but could have larger impacts for other codes.
Overall, Relay should perform better now.